### PR TITLE
Fix NIF packaging

### DIFF
--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -48,3 +48,14 @@ jobs:
       - name: Check for compile-time dependencies
         run: mix xref graph --label compile-connected --fail-above 0
         if: always()
+
+      - name: Parse the version
+        run: |
+          echo "PROJECT_VERSION=$(sed -n 's/^      version: "\(.*\)",/\1/p' mix.exs | head -n1)" >> $GITHUB_ENV
+
+      - name: Assert the version begins with a number
+        run: |
+          if [[ ! "${{ env.PROJECT_VERSION }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "${{ env.PROJECT_VERSION }} is not a valid version number"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       shell: bash
       run: |
         # Get the project version from mix.exs
-        echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' mix.exs | head -n1)" >> $GITHUB_ENV
+        echo "PROJECT_VERSION=$(sed -n 's/^      version: "\(.*\)",/\1/p' mix.exs | head -n1)" >> $GITHUB_ENV
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule LRS.MixProject do
   def project do
     [
       app: :lrs,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
The release tarballs we generated (https://github.com/Jump-App/lrs/releases/tag/v0.1.0) were missing the version in them; they were named `liblrs-v-nif-2.15...` rather than `liblrs-v0.1.0-nif-2.15...` because the version parsing in the release.yml file wasn't working.