### PR TITLE
Enable aarch64-unknown-linux-musl builds, bump to 0.1.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
         job:
           - { target: aarch64-apple-darwin        , os: macos-latest  }
           - { target: x86_64-apple-darwin         , os: macos-latest  }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04  }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-22.04  }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest, use-cross: true }
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-latest, use-cross: true }
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-latest, use-cross: true }
-          # - { target: aarch64-unknown-linux-musl  , os: ubuntu-latest, use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-latest, use-cross: true }
           # - { target: riscv64gc-unknown-linux-gnu , os: ubuntu-latest, use-cross: true }
           # - { target: x86_64-pc-windows-gnu       , os: windows-2019  }
           # - { target: x86_64-pc-windows-msvc      , os: windows-2019  }

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule LRS.MixProject do
   def project do
     [
       app: :lrs,
-      version: "0.1.6",
+      version: "0.1.7",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/native/lrs/.cargo/config.toml
+++ b/native/lrs/.cargo/config.toml
@@ -10,6 +10,13 @@ rustflags = [
   "-C", "target-feature=-crt-static"
 ]
 
+# Same as above — required to produce a cdylib on musl (rustc defaults to
+# +crt-static for musl targets, which cannot build dynamic libraries).
+[target.aarch64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=-crt-static"
+]
+
 # Provides a small build size, but takes more time to build.
 [profile.release]
 lto = true


### PR DESCRIPTION
Last dependency blocker for Jump's Alpine (musl) Docker migration — `lrs` is consumed with RustlerPrecompiled's default target list, which includes `aarch64-unknown-linux-musl`, so Alpine-ARM builds try to download that asset and 404 (v0.1.6 never shipped it; the matrix entry was commented out).

- Uncomments the `aarch64-unknown-linux-musl` matrix entry (`use-cross: true`, same as the working x86_64-musl entry). The identical cross/rustler recipe built this target successfully in Jump-App/rrule earlier today, and the crate is pure Rust (rustler + suffix) with nothing musl-hostile.
- Moves the x86_64-gnu job from the **retired** `ubuntu-20.04` runner image (jobs targeting it queue forever — same failure mode that hung rrule's windows-2019 jobs) to `ubuntu-22.04`.
- Bumps version to 0.1.7 for the release that first carries the musl asset.

This workflow runs its matrix on PRs (`LRS_FORCE_BUILD=true`), so this PR's own checks validate the new target before merge.

After merge: tag `v0.1.7`, regenerate `checksum-Elixir.LRS.exs` against the release, then bump Jump's mix.exs/mix.lock pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)